### PR TITLE
Fix skip and limit values for all docs queries

### DIFF
--- a/src/fabric_rpc.erl
+++ b/src/fabric_rpc.erl
@@ -48,7 +48,8 @@ changes(DbName, Options, StartSeq) ->
         rexi:reply(Error)
     end.
 
-all_docs(DbName, Options, #mrargs{keys=undefined} = Args) ->
+all_docs(DbName, Options, #mrargs{keys=undefined} = Args0) ->
+    Args = fix_skip_and_limit(Args0),
     {ok, Db} = get_or_create_db(DbName, Options),
     VAcc0 = #vacc{db=Db},
     couch_mrview:query_all_docs(Db, Args, fun view_cb/2, VAcc0).


### PR DESCRIPTION
This extends commit 1b3c795 to include all docs in addition to map
views and reduce views.
