### PR TITLE
Exit early when there is a quorum but list of docs is empty

### DIFF
--- a/src/fabric_doc_open_revs.erl
+++ b/src/fabric_doc_open_revs.erl
@@ -131,6 +131,8 @@ skip(#state{revs=Revs} = State) ->
 
 maybe_reply(_, [], false, _, _) ->
     noreply;
+maybe_reply(_, [], true, _, _) ->
+    {reply, {ok, []}};
 maybe_reply(DbName, ReplyDict, Complete, RepairDocs, R) ->
     case Complete orelse lists:all(fun({_,{_, C}}) -> C >= R end, ReplyDict) of
     true ->


### PR DESCRIPTION
There is no point to go through repair stage since this set of
conditions meens that the doc with given id doesn't exists.
Besides not going through repair process fixes the case when
we request open_revs=all for non existent document

BugzID: 17500
