### PR TITLE
Handle empty list of id/revs in fabric:get_missing_revs

### DIFF
--- a/src/fabric_doc_missing_revs.erl
+++ b/src/fabric_doc_missing_revs.erl
@@ -20,6 +20,8 @@
 go(DbName, AllIdsRevs) ->
     go(DbName, AllIdsRevs, []).
 
+go(_, [], _) ->
+    {ok, []};
 go(DbName, AllIdsRevs, Options) ->
     Workers = lists:map(fun({#shard{name=Name, node=Node} = Shard, IdsRevs}) ->
         Ref = rexi:cast(Node, {fabric_rpc, get_missing_revs, [Name, IdsRevs,


### PR DESCRIPTION
fabric_doc_missing_revs:go doesn't handle the case when AllIdsRevs is an empty list (resulting in a timeout). Given this will always result
in an empty response, handle this explicitly and avoid the delegation / aggregation from shards.

An alternative solution would be to fix fabric_doc_missing_revs:go to prevent the time out rather than returning immediately. Comments on that approach vs the proposed solution and guidance around where to add appropriate tests for the original problem (POST to /_revs_diff with no revisions times out in clustered CouchDB 2.0) would be much appreciated.

COUCHDB-2531