### PR TITLE
Respect doc_options during _changes serialization

### DIFF
--- a/src/fabric_rpc.erl
+++ b/src/fabric_rpc.erl
@@ -298,7 +298,11 @@ changes_enumerator(#doc_info{id= <<"_local/", _/binary>>, high_seq=Seq}, Acc) ->
 changes_enumerator(DocInfo, Acc) ->
     #cacc{
         db = Db,
-        args = #changes_args{include_docs = IncludeDocs, filter_fun = Filter},
+        args = #changes_args{
+            include_docs = IncludeDocs,
+            filter_fun = Filter,
+            doc_options = DocOptions
+        },
         options = Options,
         pending = Pending,
         epochs = Epochs
@@ -309,7 +313,7 @@ changes_enumerator(DocInfo, Acc) ->
     [] ->
         {ok, Acc#cacc{seq = Seq, pending = Pending-1}};
     Results ->
-        Opts = if Conflicts -> [conflicts]; true -> [] end,
+        Opts = if Conflicts -> [conflicts | DocOptions]; true -> DocOptions end,
         ChangesRow = {change, [
 	    {pending, Pending-1},
             {seq, {Seq, uuid(Db), owner_of(Seq, Epochs)}},
@@ -325,7 +329,7 @@ changes_enumerator(DocInfo, Acc) ->
 doc_member(Shard, DocInfo, Opts) ->
     case couch_db:open_doc(Shard, DocInfo, [deleted | Opts]) of
     {ok, Doc} ->
-        {doc, couch_doc:to_json_obj(Doc, [])};
+        {doc, couch_doc:to_json_obj(Doc, Opts)};
     Error ->
         Error
     end.


### PR DESCRIPTION
When including full documents in the changes feed response, respect doc_options (e.g. attachments=true) during JSON serialization.

Combined with https://github.com/apache/couchdb-chttpd/pull/23 this fixes COUCHDB-2522.