### PR TITLE
Restrict views in the authentication DB to admins

### DIFF
--- a/src/fabric.erl
+++ b/src/fabric.erl
@@ -315,6 +315,14 @@ query_view(Db, GroupId, ViewName, Callback, Acc0, QueryArgs)
     query_view(DbName, DDoc, ViewName, Callback, Acc0, QueryArgs);
 query_view(DbName, DDoc, ViewName, Callback, Acc0, QueryArgs0) ->
     Db = dbname(DbName), View = name(ViewName),
+    case fabric_util:is_users_db(Db) of
+    true ->
+        Req = Acc0#vacc.req,
+        FakeDb = fabric_util:fake_db([{user_ctx, Req#httpd.user_ctx}]),
+        couch_users_db:after_doc_read(DDoc, FakeDb);
+    false ->
+        ok
+    end,
     {ok, #mrst{views=Views, language=Lang}} =
         couch_mrview_util:ddoc_to_mrst(Db, DDoc),
     QueryArgs1 = couch_mrview_util:set_view_type(QueryArgs0, View, Views),

--- a/src/fabric_doc_update.erl
+++ b/src/fabric_doc_update.erl
@@ -99,8 +99,8 @@ handle_message({bad_request, Msg}, _, _) ->
     throw({bad_request, Msg}).
 
 before_doc_update(DbName, Docs, Opts) ->
-    Db = fake_db(Opts),
-    case {is_replicator_db(DbName), is_users_db(DbName)} of
+    Db = fabric_util:fake_db(Opts),
+    case {fabric_util:is_replicator_db(DbName), fabric_util:is_users_db(DbName)} of
         {true, _} ->
             [couch_replicator_manager:before_doc_update(Doc, Db) || Doc <- Docs];
         {_, true} ->
@@ -108,22 +108,6 @@ before_doc_update(DbName, Docs, Opts) ->
         _ ->
             Docs
     end.
-
-is_replicator_db(DbName) ->
-    ConfigName = list_to_binary(config:get("replicator", "db", "_replicator")),
-    DbName == ConfigName orelse path_ends_with(DbName, <<"_replicator">>).
-
-is_users_db(DbName) ->
-    ConfigName = list_to_binary(config:get(
-        "chttpd_auth", "authentication_db", "_users")),
-    DbName == ConfigName orelse path_ends_with(DbName, <<"_users">>).
-
-path_ends_with(Path, Suffix) ->
-    Suffix == couch_db:normalize_dbname(Path).
-
-fake_db(Opts) ->
-    UserCtx = couch_util:get_value(user_ctx, Opts, #user_ctx{}),
-    #db{user_ctx = UserCtx}.
 
 tag_docs([]) ->
     [];

--- a/src/fabric_util.erl
+++ b/src/fabric_util.erl
@@ -18,6 +18,7 @@
 -export([request_timeout/0, attachments_timeout/0, all_docs_timeout/0]).
 -export([stream_start/2, stream_start/4]).
 -export([log_timeout/2, remove_done_workers/2]).
+-export([is_users_db/1, is_replicator_db/1, fake_db/1]).
 
 -compile({inline, [{doc_id_and_rev,1}]}).
 
@@ -280,6 +281,22 @@ remove_ancestors_test() ->
         [kv(Bar1,2)],
         remove_ancestors([kv(Bar2,1), kv(Bar1,1)], [])
     ).
+
+is_replicator_db(DbName) ->
+    ConfigName = list_to_binary(config:get("replicator", "db", "_replicator")),
+    DbName == ConfigName orelse path_ends_with(DbName, <<"_replicator">>).
+
+is_users_db(DbName) ->
+    ConfigName = list_to_binary(config:get(
+        "chttpd_auth", "authentication_db", "_users")),
+    DbName == ConfigName orelse path_ends_with(DbName, <<"_users">>).
+
+path_ends_with(Path, Suffix) ->
+    Suffix == couch_db:normalize_dbname(Path).
+
+fake_db(Opts) ->
+    UserCtx = couch_util:get_value(user_ctx, Opts, #user_ctx{}),
+    #db{user_ctx = UserCtx}.
 
 %% test function
 kv(Item, Count) ->


### PR DESCRIPTION
This commit teaches fabric to restrict access to views in the
authentication DB to administrators by calling through to
couch_db_users:after_doc_read/2 after the design doc is read.

Because we re-use some of the functions added to support a similar
patch calling through to couch_db_users:before_doc_update/3 we
move those common functions into fabric_util.

COUCHDB-2738