### PR TITLE
Fix incorrect size values for view index information

### DIFF
--- a/src/fabric_group_info.erl
+++ b/src/fabric_group_info.erl
@@ -59,7 +59,8 @@ handle_message({rexi_EXIT, Reason}, Shard, {Counters, Acc, Ushards}) ->
 
 handle_message({ok, Info}, Shard, {Counters0, Acc, Ushards}) ->
     NewAcc = append_result(Info, Shard, Acc, Ushards),
-    Counters = fabric_dict:store(Shard, ok, Counters0),
+    Counters1 = fabric_dict:store(Shard, ok, Counters0),
+    Counters = fabric_view:remove_overlapping_shards(Shard, Counters1),
     case is_complete(Counters) of
     false ->
         {ok, {Counters, NewAcc, Ushards}};


### PR DESCRIPTION
We need to filter overlapping shards to prevent summarizing all sizes from all the shards, since we actually need the value from the one.

