### PR TITLE
Return forbidden error if encountered on any shard

### DIFF
--- a/src/fabric_util.erl
+++ b/src/fabric_util.erl
@@ -187,6 +187,8 @@ get_shard([#shard{node = Node, name = Name} | Rest], Opts, Timeout, Factor) ->
             {ok, Db};
         {Ref, {'rexi_EXIT', {{unauthorized, _} = Error, _}}} ->
             throw(Error);
+        {Ref, {'rexi_EXIT', {{forbidden, _} = Error, _}}} ->
+            throw(Error);
         {Ref, _Else} ->
             get_shard(Rest, Opts, Timeout, Factor)
         after Timeout ->


### PR DESCRIPTION
This commit fixes an issue which caused HTTP 500 errors to be
returned when an authorized user attempted to access a database
that they did not have permission to access, when cassim is
disabled.

Instead of returning an internal server error once all shards
have failed to open we add a receive clause so that we throw
a forbidden error if one is encountered on any shard. This is the
same approach we already take for unauthorized errors.

Closes COUCHDB-2948