### PR TITLE
Avoid spamming logs with write_quorum errors

### DIFF
--- a/src/fabric_doc_update.erl
+++ b/src/fabric_doc_update.erl
@@ -126,7 +126,6 @@ force_reply(Doc, [FirstReply|_] = Replies, {Health, W, Acc}) ->
     {true, Reply} ->
         {Health, W, [{Doc,Reply} | Acc]};
     false ->
-        couch_log:warning("write quorum (~p) failed for ~s", [W, Doc#doc.id]),
         case [Reply || {ok, Reply} <- Replies] of
         [] ->
             % check if all errors are identical, if so inherit health


### PR DESCRIPTION
The three metrics in fabric_doc_update:force_reply/3 were
introduced to replace the write_quorum log message however the
log line was not removed. This commit removes the log message.

Close COUCHDB-2958