### PR TITLE
Use couch_db:dbname_suffix in path_ends_with

### DIFF
--- a/src/fabric_util.erl
+++ b/src/fabric_util.erl
@@ -295,7 +295,7 @@ is_users_db(DbName) ->
     DbName == ConfigName orelse path_ends_with(DbName, <<"_users">>).
 
 path_ends_with(Path, Suffix) ->
-    Suffix == couch_db:normalize_dbname(Path).
+    Suffix =:= couch_db:dbname_suffix(Path).
 
 fake_db(Opts) ->
     UserCtx = couch_util:get_value(user_ctx, Opts, #user_ctx{}),


### PR DESCRIPTION
Replace couch_db:normalize_dbname with couch_db:dbname_suffix since the
semantic of normalize_dbname has been changed. couch_db:normalize_dbname
would return all components of the path with shard info removed from it.
couch_db:dbname_suffix on the other hand would return the last component
of the path. It would also ensure that shard's suffix is removed from
the result.

This PR depends on https://github.com/apache/couchdb-couch/pull/160

COUCHDB-2983