### PR TITLE
Fix return type in get_all_security

### DIFF
--- a/src/fabric.erl
+++ b/src/fabric.erl
@@ -147,7 +147,7 @@ get_security(DbName, Options) ->
 
 %% @doc retrieve the security object for all shards of a database
 -spec get_all_security(dbname()) ->
-    {ok, json_obj()} |
+    {ok, [{#shard{}, json_obj()}]} |
     {error, no_majority | timeout} |
     {error, atom(), any()}.
 get_all_security(DbName) ->
@@ -155,7 +155,7 @@ get_all_security(DbName) ->
 
 %% @doc retrieve the security object for all shards of a database
 -spec get_all_security(dbname(), [option()]) ->
-    {ok, json_obj()} |
+    {ok, [{#shard{}, json_obj()}]} |
     {error, no_majority | timeout} |
     {error, atom(), any()}.
 get_all_security(DbName, Options) ->


### PR DESCRIPTION
fabric:get_all_security returns list of tuples `[{Worker, Reply}]`.