### PR TITLE
Use meck:wait to fix race condition

### DIFF
--- a/src/fabric_doc_open_revs.erl
+++ b/src/fabric_doc_open_revs.erl
@@ -330,7 +330,9 @@ check_finish_quorum_newer() ->
         S0 = state0(all, false),
         {ok, S1} = handle_message({ok, [foo1(), bar1()]}, w1, S0),
         Expect = {stop, [bar1(), foo2()]},
+        ok = meck:reset(fabric),
         ?assertEqual(Expect, handle_message({ok, [foo2(), bar1()]}, w2, S1)),
+        ok = meck:wait(fabric, update_docs, '_', 5000),
         ?assertMatch(
             [{_, {fabric, update_docs, [_, _, _]}, _}],
             meck:history(fabric)


### PR DESCRIPTION
fabric:update_docs is running in the context of a `read_repair` which is an
independent process started using `erlang:spawn/1`. This leads to a race
when we try to use `meck:history(fabric)`. Use of `meck:wait` ensures that
we call `meck:history` after `fabric:update_docs` has been called.