### PR TITLE
Fix rexi_DOWN and rexi_EXIT handlers

### DIFF
--- a/src/fabric_doc_open_revs.erl
+++ b/src/fabric_doc_open_revs.erl
@@ -160,8 +160,10 @@ sort_key({{not_found, _}, {Pos, Rev}}) ->
 
 
 dict_replies(Dict, []) ->
-    Counts = [Count || {_Key, {_Reply, Count}} <- Dict],
-    {Dict, lists:min(Counts)};
+    case [Count || {_Key, {_Reply, Count}} <- Dict] of
+        [] -> {Dict, 0};
+        Counts -> {Dict, lists:min(Counts)}
+    end;
 
 dict_replies(Dict, [Reply | Rest]) ->
     NewDict = fabric_util:update_counter(Reply, 1, Dict),


### PR DESCRIPTION
In the cases when we receive rexi_DOWN or rexi_EXIT we call
handle_message with {ok, []}. This crashes lists:min/1. Since it expects
a list with at least one element.

COUCHDB-3037