### PR TITLE
Fix match in fabric_doc_open_revs reply

### DIFF
--- a/src/fabric_doc_open_revs.erl
+++ b/src/fabric_doc_open_revs.erl
@@ -46,8 +46,8 @@ go(DbName, Id, Revs, Options) ->
     },
     RexiMon = fabric_util:create_monitors(Workers),
     try fabric_util:recv(Workers, #shard.ref, fun handle_message/3, State) of
-    {ok, {ok, Reply}} ->
-        {ok, filter_reply(Reply)};
+    {ok, Replies} ->
+        {ok, filter_reply(Replies)};
     {timeout, #state{workers=DefunctWorkers}} ->
         fabric_util:log_timeout(DefunctWorkers, "open_revs"),
         {error, timeout};


### PR DESCRIPTION
Message handler in `fabric_doc_open_revs` returns tagged with 'ok' list of the replies and not expected `{ok, Reply}` tuple. This makes reply to go through `Else` clause and skip `filter_reply` function.