### PR TITLE
End the listener if any shard is deleted

### DIFF
--- a/src/fabric_db_update_listener.erl
+++ b/src/fabric_db_update_listener.erl
@@ -83,7 +83,9 @@ start_update_notifier(DbNames) ->
 handle_db_event(_DbName, updated, #cb_state{notify = true} = St) ->
     erlang:send(St#cb_state.client_pid, {St#cb_state.client_ref, db_updated}),
     {ok, St};
-handle_db_event(_DbName, _Event, St) ->
+handle_db_event(_DbName, deleted, St) ->
+    {stop, St};
+handle_db_event(DbName, Event, St) ->
     {ok, St}.
 
 start_cleanup_monitor(Parent, Notifiers) ->


### PR DESCRIPTION
If a database is deleted and recreated the underlying shards have a
new name. Since we're watching the old names, we will never again see
an updated event. So, we stop this process if any watched shard is
deleted and it's someone elses job to recreate the listener for the
new shards.

COUCHDB-3054