### PR TITLE
77984 upgrade mrargs record4

### DIFF
--- a/src/fabric_util.erl
+++ b/src/fabric_util.erl
@@ -19,12 +19,14 @@
 -export([stream_start/2, stream_start/4]).
 -export([log_timeout/2, remove_done_workers/2]).
 -export([is_users_db/1, is_replicator_db/1, fake_db/2]).
+-export([upgrade_mrargs/1]).
 
 -compile({inline, [{doc_id_and_rev,1}]}).
 
 -include_lib("fabric/include/fabric.hrl").
 -include_lib("mem3/include/mem3.hrl").
 -include_lib("couch/include/couch_db.hrl").
+-include_lib("couch_mrview/include/couch_mrview.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 remove_down_workers(Workers, BadNode) ->
@@ -308,3 +310,63 @@ kv(Item, Count) ->
 
 doc_id_and_rev(#doc{id=DocId, revs={RevNum, [RevHash|_]}}) ->
     {DocId, {RevNum, RevHash}}.
+
+
+upgrade_mrargs(#mrargs{} = Args) ->
+    Args;
+
+upgrade_mrargs({mrargs,
+        ViewType,
+        Reduce,
+        PreflightFun,
+        StartKey,
+        StartKeyDocId,
+        EndKey,
+        EndKeyDocId,
+        Keys,
+        Direction,
+        Limit,
+        Skip,
+        GroupLevel,
+        Group,
+        Stable,
+        Update,
+        MultiGet,
+        InclusiveEnd,
+        IncludeDocs,
+        DocOptions,
+        UpdateSeq,
+        Conflicts,
+        Callback,
+        Sorted,
+        Extra}) ->
+    Stale = case {Stable, Update} of
+            {true, false} -> ok;
+            {true, lazy} -> update_after;
+            {_, _} -> false
+    end,
+    #mrargs{
+        view_type = ViewType,
+        reduce = Reduce,
+        preflight_fun = PreflightFun,
+        start_key = StartKey,
+        start_key_docid = StartKeyDocId,
+        end_key = EndKey,
+        end_key_docid = EndKeyDocId,
+        keys = Keys,
+        direction = Direction,
+        limit = Limit,
+        skip = Skip,
+        group_level = GroupLevel,
+        group = Group,
+        stale = Stale,
+        multi_get = MultiGet,
+        inclusive_end = InclusiveEnd,
+        include_docs = IncludeDocs,
+        doc_options = DocOptions,
+        update_seq = UpdateSeq,
+        conflicts = Conflicts,
+        callback = Callback,
+        sorted = Sorted,
+        extra = Extra
+    }.

--- a/src/fabric_util.erl
+++ b/src/fabric_util.erl
@@ -329,8 +329,7 @@ upgrade_mrargs({mrargs,
         Skip,
         GroupLevel,
         Group,
-        Stable,
-        Update,
+        Stale,
         MultiGet,
         InclusiveEnd,
         IncludeDocs,
@@ -340,10 +339,10 @@ upgrade_mrargs({mrargs,
         Callback,
         Sorted,
         Extra}) ->
-    Stale = case {Stable, Update} of
-            {true, false} -> ok;
-            {true, lazy} -> update_after;
-            {_, _} -> false
+    {Stable, Update} = case Stale of
+        ok -> {true, false};
+        update_after -> {true, lazy};
+        _ -> {false, true}
     end,
     #mrargs{
         view_type = ViewType,
@@ -359,7 +358,8 @@ upgrade_mrargs({mrargs,
         skip = Skip,
         group_level = GroupLevel,
         group = Group,
-        stale = Stale,
+        stable = Stable,
+        update = Update,
         multi_get = MultiGet,
         inclusive_end = InclusiveEnd,
         include_docs = IncludeDocs,

--- a/src/fabric_view.erl
+++ b/src/fabric_view.erl
@@ -302,14 +302,13 @@ index_of(X, [X|_Rest], I) ->
 index_of(X, [_|Rest], I) ->
     index_of(X, Rest, I+1).
 
-get_shards(DbName, #mrargs{stale=Stale})
-  when Stale == ok orelse Stale == update_after ->
+get_shards(DbName, #mrargs{stable=true}) ->
     mem3:ushards(DbName);
-get_shards(DbName, #mrargs{stale=false}) ->
+get_shards(DbName, #mrargs{stable=false}) ->
     mem3:shards(DbName).
 
 maybe_update_others(DbName, DDoc, ShardsInvolved, ViewName,
-    #mrargs{stale=update_after} = Args) ->
+    #mrargs{update=lazy} = Args) ->
     ShardsNeedUpdated = mem3:shards(DbName) -- ShardsInvolved,
     lists:foreach(fun(#shard{node=Node, name=ShardName}) ->
         rpc:cast(Node, fabric_rpc, update_mrview, [ShardName, DDoc, ViewName, Args])

--- a/src/fabric_view.erl
+++ b/src/fabric_view.erl
@@ -302,13 +302,14 @@ index_of(X, [X|_Rest], I) ->
 index_of(X, [_|Rest], I) ->
     index_of(X, Rest, I+1).
 
-get_shards(DbName, #mrargs{stable=true}) ->
+get_shards(DbName, #mrargs{stale=Stale})
+  when Stale == ok orelse Stale == update_after ->
     mem3:ushards(DbName);
-get_shards(DbName, #mrargs{stable=false}) ->
+get_shards(DbName, #mrargs{stale=false}) ->
     mem3:shards(DbName).
 
 maybe_update_others(DbName, DDoc, ShardsInvolved, ViewName,
-    #mrargs{update=lazy} = Args) ->
+    #mrargs{stale=update_after} = Args) ->
     ShardsNeedUpdated = mem3:shards(DbName) -- ShardsInvolved,
     lists:foreach(fun(#shard{node=Node, name=ShardName}) ->
         rpc:cast(Node, fabric_rpc, update_mrview, [ShardName, DDoc, ViewName, Args])


### PR DESCRIPTION
Upgrade `#mrargs{}` record in two steps. 

# First release would have following

- fabric [Compatibility clause for the record upgrade](https://github.com/apache/couchdb-fabric/commit/ebb43d5452fc20cf26ed616d5076a8d4f38caafc)
- mrview [Merge remote-tracking branch 'cloudant/COUCHDB-3150-add-new-function-to-get-view-index-pid'](https://github.com/apache/couchdb-couch-mrview/commit/d27941193516b925959cf3d27db7ba8f6524ba25)

# Second release would have

- fabric [ 	Revert "Revert "Merge remote-tracking branch 'banjiewen/stale-stable-..](https://github.com/apache/couchdb-fabric/commit/5d91018b2fa317198a848c19d60a45dea8091725)
- mrview [Merge remote-tracking branch 'banjiewen/stale-stable-update' ](https://github.com/apache/couchdb-couch-mrview/commit/d4509606f3aacc4bec94b8936bedf6d1d597ff5f)



