### PR TITLE
Include conflicts parameter in doc_options

### DIFF
--- a/src/fabric_view_all_docs.erl
+++ b/src/fabric_view_all_docs.erl
@@ -54,14 +54,19 @@ go(DbName, Options, QueryArgs, Callback, Acc0) ->
     #mrargs{
         direction = Dir,
         include_docs = IncludeDocs,
-        doc_options = Doc_Options,
+        doc_options = DocOptions0,
         limit = Limit,
+        conflicts = Conflicts,
         skip = Skip,
         keys = Keys0
     } = QueryArgs,
     {_, Ref0} = spawn_monitor(fun() -> exit(fabric:get_doc_count(DbName)) end),
+    DocOptions1 = case Conflicts of
+        true -> [conflicts|DocOptions0];
+        _ -> DocOptions0
+    end,
     SpawnFun = fun(Key) ->
-        spawn_monitor(?MODULE, open_doc, [DbName, Options ++ Doc_Options, Key, IncludeDocs])
+        spawn_monitor(?MODULE, open_doc, [DbName, Options ++ DocOptions1, Key, IncludeDocs])
     end,
     MaxJobs = all_docs_concurrency(),
     Keys1 = case Dir of


### PR DESCRIPTION
When a keys array is passed to _all_docs, fabric translates this
to individual open_doc calls. The conflicts=true query parameter is
specified as a view-level option and is not, by default, parsed as
an option that should be passed to open_doc.

As a workaround, explicitly copy the view-level conflict parameter into
the document options before open_doc is called.

An alternative approach would be to address this when the query
parameters are parsed, setting conflicts=true in both #mrargs and
detail of fabric, I elected to make the change here instead.

Fixes #COUCHDB-3264