### PR TITLE
Handle no_pass message when limit is 0

### DIFF
--- a/src/fabric_rpc.erl
+++ b/src/fabric_rpc.erl
@@ -351,7 +351,9 @@ changes_enumerator(DocInfo, Acc) ->
     #doc_info{id=Id, high_seq=Seq, revs=[#rev_info{deleted=Del}|_]} = DocInfo,
     case [X || X <- couch_changes:filter(Db, DocInfo, Filter), X /= null] of
     [] ->
-        ChangesRow = {no_pass, Seq};
+        ChangesRow = {no_pass, [
+            {pending, Pending-1},
+            {seq, Seq}]};
     Results ->
         Opts = if Conflicts -> [conflicts | DocOptions]; true -> DocOptions end,
         ChangesRow = {change, [


### PR DESCRIPTION
A view query that uses both a filter and a limit value can appear to
'hang' because the workers continue to run even after the number of
requested items have been returned, as workers that find no more
matches return 'no_pass' messages not 'change' messages, and thus the
short-circuiting code is never activated.

COUCHDB-3269