### PR TITLE
Fix open revs quorum when error

### DIFF
--- a/src/fabric_doc_open_revs.erl
+++ b/src/fabric_doc_open_revs.erl
@@ -465,7 +465,7 @@ check_worker_error_skipped() ->
 
         {ok, S1} = handle_message(Msg1, w1, S0),
         {ok, S2} = handle_message(Msg2, w2, S1),
-        ?assertEqual(Expect, handle_message(Msg3, w2, S2))
+        ?assertEqual(Expect, handle_message(Msg3, w3, S2))
     end).
 
 


### PR DESCRIPTION
 In open_revs, do not count errors in quorum threshold calculation

Previously quorum check looked just at the number of replies and decided quorum
was met even if it only received errors. For example, if 2 nodes are in
maintance mode it might receive this sequence of replies:

  `rexi_EXIT, rexi_EXIT, ok`

In that case after the first two it would decide quorum (r=2) was met, return
what it had so far ([]) and kill the remaining worker, who was about to return
a valid revision.

The fix is to keep track of error replies and subtract them when deciding if
quorum was met.

Also fix a typo in another unit test ( a separate commit ).