### PR TITLE
Add admin ctx on open ddoc in group_info

### DIFF
--- a/src/fabric_group_info.erl
+++ b/src/fabric_group_info.erl
@@ -19,7 +19,7 @@
 -include_lib("couch/include/couch_db.hrl").
 
 go(DbName, GroupId) when is_binary(GroupId) ->
-    {ok, DDoc} = fabric:open_doc(DbName, GroupId, []),
+    {ok, DDoc} = fabric:open_doc(DbName, GroupId, [?ADMIN_CTX]),
     go(DbName, DDoc);
 
 go(DbName, #doc{id=DDocId}) ->


### PR DESCRIPTION
Group info on ddocs in _users database require admin privileges.

COUCHDB-3279