### PR TITLE
Add Else Clause For Embed Doc

### DIFF
--- a/src/fabric_view.erl
+++ b/src/fabric_view.erl
@@ -172,7 +172,9 @@ possibly_embed_doc(#collector{db_name=DbName, query_args=Args},
                     {ok, NewDoc} ->
                         Row#view_row{doc=couch_doc:to_json_obj(NewDoc,[])};
                     {not_found, _} ->
-                        Row#view_row{doc=null}
+                        Row#view_row{doc=null};
+                    Else ->
+                        Row#view_row{doc={error, Else}}
                     end;
                 Rev0 ->
                     Rev = couch_doc:parse_rev(Rev0),
@@ -180,7 +182,9 @@ possibly_embed_doc(#collector{db_name=DbName, query_args=Args},
                     {ok, [{ok, NewDoc}]} ->
                         Row#view_row{doc=couch_doc:to_json_obj(NewDoc,[])};
                     {ok, [{{not_found, _}, Rev}]} ->
-                        Row#view_row{doc=null}
+                        Row#view_row{doc=null};
+                    Else ->
+                        Row#view_row{doc={error, Else}}
                     end
                 end) end),
             receive {'DOWN',Ref,process,Pid, Resp} ->


### PR DESCRIPTION
When open_doc or open_revs return an error, we set the doc value
to be an error message. This way we account for errors rather than
transform_row throwing a function_clause.

This PR will not be merged until https://github.com/apache/couchdb-fabric/pull/86 is merged.

COUCHDB-3109