### PR TITLE
Prevent attachment upload from timing out during update_docs fabric call

### DIFF
--- a/src/fabric_rpc.erl
+++ b/src/fabric_rpc.erl
@@ -422,6 +422,7 @@ make_att_reader({follows, Parser, Ref}) ->
         Parser ! {get_bytes, Ref, self()},
         receive
             {bytes, Ref, Bytes} ->
+                rexi:reply(attachment_chunk_received),
                 Bytes;
             {'DOWN', ParserRef, _, _, Reason} ->
                 throw({mp_parser_died, Reason})


### PR DESCRIPTION
Currently if an attachment was large enough or the connection was slow enough
such that it took more than fabric.request_timeout = 60000 milliseconds, the
fabric request would time out during attachment data transfer from coordinator
node to other nodes and the whole request would fail.

This was most evident when replicating database with large attachments.

The fix is to periodically send `attachment_chunk_received` to coordinator to
prevent the timeout.

COUCHDB-3302