### PR TITLE
Modify row when reduction input is invalid

### DIFF
--- a/src/fabric_view.erl
+++ b/src/fabric_view.erl
@@ -254,6 +254,9 @@ find_next_key([], _, _, _) ->
 find_next_key([Key|Rest], _, _, _) ->
     {Key, Rest}.
 
+transform_row(#view_row{id=reduced, value={[{builtin_reduce_error,Reason},
+        {invalid_value,Value}]}}) ->
+    {row, [{id,builtin_reduce_error}, {reason,Reason}, {value,Value}]};
 transform_row(#view_row{key=Key, id=reduced, value=Value}) ->
     {row, [{key,Key}, {value,Value}]};
 transform_row(#view_row{key=Key, id=undefined}) ->


### PR DESCRIPTION
When an input is invalid for a reduction, couch_query_servers will
return an error. This change takes that error and transforms it so
that the view callback in couch_mrview can accept it.

This is a supplement PR to https://github.com/apache/couchdb-couch/pull/229