### PR TITLE
Allow limiting maximum document body size

### DIFF
--- a/src/fabric.erl
+++ b/src/fabric.erl
@@ -497,7 +497,7 @@ docs(Docs) ->
 doc(#doc{} = Doc) ->
     Doc;
 doc({_} = Doc) ->
-    couch_doc:from_json_obj(Doc);
+    couch_doc:from_json_obj_validate(Doc);
 doc(Doc) ->
     erlang:error({illegal_doc_format, Doc}).
 


### PR DESCRIPTION
Update doc function to check and validate document body sizes

Main implementation is in PR:

 https://github.com/apache/couchdb-couch/pull/235

COUCHDB-2992